### PR TITLE
#32 | Fix "access to private variable of parent class" in SkinLakeus.php

### DIFF
--- a/RELEASE-NOTES-1.1.md
+++ b/RELEASE-NOTES-1.1.md
@@ -38,6 +38,9 @@ risk!
 * Removed unnecessary modules.
 * Fixed CodeMirror glitch.
 * (issue #26) Removed unneeded `wp` prefix from `hide-if`.
+* (issue #32) Fixed "access to private variable `$templateParser` of parent
+  class" in `SkinLakeus.php` by dropping unneeded
+  `BagOStuff $localServerObjectCache` dependency.
 * …
 
 ### Action API changes

--- a/includes/SkinLakeus.php
+++ b/includes/SkinLakeus.php
@@ -2,24 +2,11 @@
 
 namespace MediaWiki\Skins\Lakeus;
 
-use BagOStuff;
-# use MediaWiki\Html\TemplateParser; // Namespaced in 1.40.0
 # use MediaWiki\SiteStats\SiteStats; // Namespaced in 1.41.0
 use SiteStats;
 use SkinMustache;
-use TemplateParser;
 
 class SkinLakeus extends SkinMustache {
-	/**
-	 * @param BagOStuff $localServerObjectCache
-	 * @param array $options
-	 */
-	public function __construct( BagOStuff $localServerObjectCache, array $options ) {
-		parent::__construct( $options );
-
-		$this->templateParser = new TemplateParser( $this->options['templateDirectory'], $localServerObjectCache );
-	}
-
 	/**
 	 * Extends the getTemplateData function to add a template key 'html-myskin-hello-world'
 	 * which can be rendered in skin.mustache using {{{html-myskin-hello-world}}}

--- a/skin.json
+++ b/skin.json
@@ -229,9 +229,6 @@
 	"ValidSkinNames": {
 		"lakeus": {
 			"class": "MediaWiki\\Skins\\Lakeus\\SkinLakeus",
-			"services": [
-				"LocalServerObjectCache"
-			],
 			"args": [
 				{
 					"name": "lakeus",


### PR DESCRIPTION
# SkinLakeus.php declaration fix.

This is my first time doing an actual pull request.

So, this is a fix to declare the $templateParser property in the SkinLakeus.php file, specifically the class.  
This fix was created in response to a deprecation warning.

![Deprecation warning that says that you are trying to declare a dynamic property](https://github.com/lakejason0/mediawiki-skins-Lakeus/assets/73059135/f3f086f2-9697-4991-a4a3-2f7ff4e0d18e)


And if you are asking what MediaWiki am I running this on, here is a screenshot.

![Mediawiki 1.41.0 screenshot of version](https://github.com/lakejason0/mediawiki-skins-Lakeus/assets/73059135/83876654-fba4-4cd5-ba2f-3389f49a8ca2)

I am indeed running mediawiki 1.41.0