### PR TITLE
#33 | Migrate templateDirectory option to skin.json

### DIFF
--- a/RELEASE-NOTES-1.1.md
+++ b/RELEASE-NOTES-1.1.md
@@ -65,12 +65,13 @@ Below only new and removed languages are listed.
 
 ### Deprecations
 
+* (issue #24) Converted to the new hook system.
+* (T262067, issue #33) Migrated `templateDirectory` option to `skin.json`.
 * …
 
 ### Other changes
 
 * (issue #22) Fixed capitalization in README.
-* (issue #24) Converted to the new hook system.
 * Reordered skin.json based on mediawiki/core `docs/extension.schema.v2.json`
   (`6d71df9`).
 * (issue #28, #29) Added documentations.

--- a/includes/SkinLakeus.php
+++ b/includes/SkinLakeus.php
@@ -10,15 +10,11 @@ use SkinMustache;
 use TemplateParser;
 
 class SkinLakeus extends SkinMustache {
-
-	public const TEMPLATE_DIR = __DIR__ . '/templates';
-
 	/**
 	 * @param BagOStuff $localServerObjectCache
 	 * @param array $options
 	 */
 	public function __construct( BagOStuff $localServerObjectCache, array $options ) {
-		$options['templateDirectory'] = self::TEMPLATE_DIR;
 		parent::__construct( $options );
 
 		$this->templateParser = new TemplateParser( $this->options['templateDirectory'], $localServerObjectCache );

--- a/skin.json
+++ b/skin.json
@@ -235,6 +235,7 @@
 			"args": [
 				{
 					"name": "lakeus",
+					"templateDirectory": "includes/templates",
 					"responsive": true,
 					"styles": [
 						"mediawiki.hlist",


### PR DESCRIPTION
See: mediawiki/core 1.35.0
Change-Id Ibbabd1d0f26efebf8f8ff068966685dc2191c527 (commit 26d5f78f84d57fca007700f143b2c51ab8840d69 ) See mediawiki/skins/Vector
Change-Id Ieccdf87979d14eeec0834b6b0cecf064d5fd9cfc (commit 3435f8fd9b3cc5a38560ed75a6d8440df4e1cd54 )

Bug: T262067
Bug: #33
Change-Id: I8eedbebbf1782bfcfbd35e4ed113e9a71c11e0ff