### PR TITLE
#38 | Drop support for MediaWiki 1.37.x, 1.38.x

### DIFF
--- a/RELEASE-NOTES-1.1.md
+++ b/RELEASE-NOTES-1.1.md
@@ -1,5 +1,80 @@
 # mediawiki-skins-Lakeus 1.1
 
+## mediawiki-skins-Lakeus master branch
+
+THIS IS NOT A RELEASE YET
+
+The `master` branch is an alpha-quality development branch. Use it at your own
+risk!
+
+### Configuration changes for system administrators
+
+#### New configuration
+
+* …
+
+#### Changed configuration
+
+* …
+
+#### Removed configuration
+
+* …
+
+### New user-facing features
+
+* …
+
+### New features for sysadmins
+
+* …
+
+### New developer features
+
+* …
+
+### Bug fixes
+
+* …
+
+### Action API changes
+
+* …
+
+### Action API internal changes
+
+* …
+
+### Languages updated
+
+Lakeus skin now supports 27 languages. Many localisations are updated regularly.
+
+Below only new and removed languages are listed.
+
+* …
+
+### Breaking changes
+
+* …
+
+### Deprecations
+
+* (issue #38) Support for obsoleted MediaWiki version 1.37.x, 1.38.x were
+  dropped.
+* (issue #38) Replaced deprecated PHP class alias `ResourceLoaderSkinModule`
+  with namespaced `MediaWiki\ResourceLoader\SkinModule`.\
+  The class was namespaced in MediaWiki 1.39
+  (commit 3e2653f83bc096889d8b69d1e01a52d7de42b247,
+  Change-Id Id08a220e1d6085e2b33f3f6c9d0e3935a4204659),\
+  and the deprecated class alias was removed in MediaWiki 1.42
+  (commit 21d8d9863b393e0bea608ac2f926b40bfecff9ad,
+  Change-Id I5929a2f760c8d21c1cb2542a19220a91ac7240e4).
+* …
+
+### Other changes
+
+* …
+
 ## mediawiki-skins-Lakeus 1.1.18
 
 This is a maintenance release of the mediawiki-skins-Lakeus 1.1 version.

--- a/skin.json
+++ b/skin.json
@@ -14,7 +14,7 @@
 	"descriptionmsg": "lakeus-skin-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.36.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "",
@@ -22,7 +22,7 @@
 	},
 	"ResourceModules": {
 		"skins.lakeus.styles": {
-			"class": "ResourceLoaderSkinModule",
+			"class": "MediaWiki\\ResourceLoader\\SkinModule",
 			"features": {
 				"normalize": true,
 				"elements": true,


### PR DESCRIPTION
Replaced deprecated PHP class alias `ResourceLoaderSkinModule` with namespaced `MediaWiki\ResourceLoader\SkinModule`.\

The class was namespaced in MediaWiki 1.39
(commit 3e2653f83bc096889d8b69d1e01a52d7de42b247,
Change-Id Id08a220e1d6085e2b33f3f6c9d0e3935a4204659),

and the deprecated class alias was removed in MediaWiki 1.42 (commit 21d8d9863b393e0bea608ac2f926b40bfecff9ad,
Change-Id I5929a2f760c8d21c1cb2542a19220a91ac7240e4).

Bug: #38
Change-Id: I49315facdd5cc0f56485c830c020853763bf76c0