### PR TITLE
#43 | Fix content width changing when switching tabs - 6

### DIFF
--- a/resources/skin.less
+++ b/resources/skin.less
@@ -172,7 +172,7 @@ p {
   color: @text-color-body;
 
   @media screen and ( min-width: @width-breakpoint-tablet ) {
-    width: max( @width-breakpoint-tablet, ~"70%" );
+    width: ~"max(" @width-breakpoint-tablet, ~"70% )";
     max-width: 100%;
   }
 
@@ -585,7 +585,7 @@ main {
   margin-top: 40px;
 
   @media screen and ( min-width: @width-breakpoint-tablet ) {
-    width: max( @width-breakpoint-tablet, ~"70%" );
+    width: ~"max(" @width-breakpoint-tablet, ~"70% )";
     margin: 10px auto 40px;
   }
 }


### PR DESCRIPTION
Fix content width changing when switching tabs in Special:Preferences - attempt 6.

Caused by min() , max() .

Bug: #40
Bug: #41
Bug: #42
Bug: #43
Change-Id: I1b3d150b8231244948ebd83f92e0f256cfb6f1ac