### PR TITLE
#44 | Fix too-wide sidebar in narrow screen

### DIFF
--- a/RELEASE-NOTES-1.2.md
+++ b/RELEASE-NOTES-1.2.md
@@ -1,5 +1,73 @@
 # mediawiki-skins-Lakeus 1.2
 
+## mediawiki-skins-Lakeus master branch
+
+THIS IS NOT A RELEASE YET
+
+The `master` branch is an alpha-quality development branch. Use it at your own
+risk!
+
+### Configuration changes for system administrators
+
+#### New configuration
+
+* …
+
+#### Changed configuration
+
+* …
+
+#### Removed configuration
+
+* …
+
+### New user-facing features
+
+* …
+
+### New features for sysadmins
+
+* …
+
+### New developer features
+
+* …
+
+### Bug fixes
+
+* (issue #44) Fixed too-wide sidebar in narrow screen, causing cannot
+  tap-to-close.
+* (issue #44) Fixed the sidebar became too narrow if the texts in sidebar are
+  too short.
+
+### Action API changes
+
+* …
+
+### Action API internal changes
+
+* …
+
+### Languages updated
+
+Lakeus skin now supports 27 languages. Many localisations are updated regularly.
+
+Below only new and removed languages are listed.
+
+* …
+
+### Breaking changes
+
+* …
+
+### Deprecations
+
+* …
+
+### Other changes
+
+* …
+
 ## mediawiki-skins-Lakeus 1.2.0
 
 This is the first release of the mediawiki-skins-Lakeus 1.2 version.

--- a/resources/skin.less
+++ b/resources/skin.less
@@ -369,14 +369,14 @@ p {
   position: fixed;
   left: 0;
   top: 0;
-  width: 30%;
+  width: max-content;
   bottom: 0;
   background: @background-color-toggle-list;
   z-index: 13;
   height: 100%;
   overflow-y: auto;
-  min-width: max-content;
-  max-width: 500px;
+  min-width: ~"max( 224px, 30% )";
+  max-width: ~"min( calc( 100% - 80px ), 500px )";
   transform: translateX( -100% );
   transition: cubic-bezier( 0.4, 0, 0.2, 1 ) 0.2s transform;
 


### PR DESCRIPTION
Fix too-wide sidebar in narrow screen, causing cannot tap-to-close.

min-width: max-content; would cause the sidebar won't wrap texts in narrow
screens.

Also fix the sidebar became too narrow if the texts in sidebar are too short.

Bug: #44
Change-Id: I1272edf8fc488160eb717e40ad75fa3ecf432ace