### PR TITLE
#58 | Fix CodeMirror 6 in VisualEditor misalignment

### DIFF
--- a/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
+++ b/skinStyles/extensions/VisualEditor/ext.visualEditor.desktopArticleTarget.init.less
@@ -13,7 +13,8 @@
 
 }
 
-/* Codemirror for visual editor doesn't need padding */
-.ve-init-mw-desktopArticleTarget .CodeMirror {
+/* CodeMirror for visual editor doesn't need padding */
+.ve-init-mw-desktopArticleTarget .CodeMirror,
+.ve-init-mw-desktopArticleTarget .cm-editor {
 	padding: 0 !important;
 }


### PR DESCRIPTION
Bug: https://phabricator.wikimedia.org/T357482
Bug: #57