### PR TITLE
#67 | Turn HTML comment into a Mustache comment

### DIFF
--- a/includes/templates/ContentHeading.mustache
+++ b/includes/templates/ContentHeading.mustache
@@ -1,2 +1,2 @@
 <h1 class="firstHeading content__heading" {{{html-user-language-attributes}}}>{{{html-title}}}</h1>
-<!--<a href="#lang" class="mw-interlanguage-selector mw-ui-button content__language-btn">{{msg-otherlanguages}}</a>-->
+{{! <a href="#lang" class="mw-interlanguage-selector mw-ui-button content__language-btn">{{msg-otherlanguages}}</a> }}


### PR DESCRIPTION
HTML comments are shipped to the browser by MediaWiki, while Mustache comments are not. This reduces the amount of HTML that needs to be shipped.