### PR TITLE
#68 | Remove broken Mustache comment

### DIFF
--- a/includes/templates/ContentHeading.mustache
+++ b/includes/templates/ContentHeading.mustache
@@ -1,2 +1,1 @@
 <h1 class="firstHeading content__heading" {{{html-user-language-attributes}}}>{{{html-title}}}</h1>
-{{! <a href="#lang" class="mw-interlanguage-selector mw-ui-button content__language-btn">{{msg-otherlanguages}}</a> }}


### PR DESCRIPTION
"{{msg-otherlanguages}}" terminated the comment block so "\</a> }}" was written to outputs.

Mustache specification says:
The tag's content may contain any substring
(including newlines) EXCEPT the closing delimiter.

Fixes: 99414ecfce79 ("Turn HTML comment into a Mustache comment")